### PR TITLE
"Edit This Page" links on the doc are now linked to corresponding edit pages on GitHub

### DIFF
--- a/book.json
+++ b/book.json
@@ -6,7 +6,7 @@
   "plugins": ["edit-link", "prism", "-highlight", "github", "anchorjs"],
   "pluginsConfig": {
     "edit-link": {
-      "base": "https://github.com/kubernetes-incubator/kube-aws/tree/master/docs",
+      "base": "https://github.com/kubernetes-incubator/kube-aws/edit/master/docs",
       "label": "Edit This Page"
     },
     "github": {


### PR DESCRIPTION
Anyone other than admins are forced to fork and send a pull request to apply changes, rather than directly commiting to the master branch
Ref https://github.com/kubernetes-incubator/kube-aws/pull/861#issuecomment-324237973
