### PR TITLE
fix: Partial upgrades with stack name overrides

### DIFF
--- a/core/root/operation_targets.go
+++ b/core/root/operation_targets.go
@@ -2,19 +2,9 @@ package root
 
 import "strings"
 
-// TODO: Add etcd
 const (
-	OperationTargetControlPlane = "control-plane"
-	OperationTargetEtcd         = "etcd"
-	OperationTargetNetwork      = "network"
-	OperationTargetAll          = "all"
+	OperationTargetAll = "all"
 )
-
-var OperationTargetNames = []string{
-	OperationTargetControlPlane,
-	OperationTargetEtcd,
-	OperationTargetNetwork,
-}
 
 type OperationTargets []string
 
@@ -22,9 +12,9 @@ func AllOperationTargetsAsStringSlice() []string {
 	return []string{"all"}
 }
 
-func AllOperationTargetsWith(nodePoolNames []string) OperationTargets {
+func AllOperationTargetsWith(nodePoolNames []string, operationTargetNames []string) OperationTargets {
 	ts := []string{}
-	ts = append(ts, OperationTargetNames...)
+	ts = append(ts, operationTargetNames...)
 	ts = append(ts, nodePoolNames...)
 	return OperationTargets(ts)
 }
@@ -42,31 +32,36 @@ func (ts OperationTargets) IncludeWorker(nodePoolName string) bool {
 	return false
 }
 
-func (ts OperationTargets) IncludeNetwork() bool {
+func (ts OperationTargets) IncludeNetwork(networkStackName string) bool {
 	for _, t := range ts {
-		if t == OperationTargetNetwork {
+		if t == networkStackName {
 			return true
 		}
 	}
 	return false
 }
 
-func (ts OperationTargets) IncludeControlPlane() bool {
+func (ts OperationTargets) IncludeControlPlane(controlPlaneStackName string) bool {
 	for _, t := range ts {
-		if t == OperationTargetControlPlane {
+		if t == controlPlaneStackName {
 			return true
 		}
 	}
 	return false
 }
 
-func (ts OperationTargets) IncludeEtcd() bool {
+func (ts OperationTargets) IncludeEtcd(etcdStackName string) bool {
 	for _, t := range ts {
-		if t == OperationTargetEtcd {
+		if t == etcdStackName {
 			return true
 		}
 	}
 	return false
+}
+func (ts OperationTargets) IncludeAll(cl *Cluster) bool {
+	return ts.IncludeNetwork(cl.Network().Config.NetworkStackName()) &&
+		ts.IncludeControlPlane(cl.ControlPlane().Config.ControlPlaneStackName()) &&
+		ts.IncludeEtcd(cl.Etcd().Config.EtcdStackName())
 }
 
 func (ts OperationTargets) IsAll() bool {


### PR DESCRIPTION
With https://github.com/kubernetes-incubator/kube-aws/pull/1524, this issue has been fixed in the v0.12.x branch.

This PR fixes this issue in the latest master branch.

See the conversation in https://github.com/kubernetes-incubator/kube-aws/pull/1524 for more information.