### PR TITLE
feat: support for AWS mixed instances

### DIFF
--- a/builtin/files/cluster.yaml.tmpl
+++ b/builtin/files/cluster.yaml.tmpl
@@ -481,6 +481,7 @@ worker:
 #          onDemandPercentageAboveBaseCapacity: 0
 #          spotAllocationStrategy: lowest-price
 #          spotInstancePools: 2
+#          # Omit spotMaxPrice for default behaviour: max price = on-demand price
 #          spotMaxPrice: 2
 #          instanceTypes:
 #          - t2.medium

--- a/builtin/files/cluster.yaml.tmpl
+++ b/builtin/files/cluster.yaml.tmpl
@@ -464,10 +464,26 @@ worker:
 #        maxBatchSize: 1
 #
 #      # Auto Scaling Group definition for workers. If only `workerCount` is specified, min and max will be the set to that value and `rollingUpdateMinInstancesInService` will be one less.
+#      # NOTE: Starting kube-aws 0.13, this creates a LaunchTemplate instead of a LaunchConfiguration. This makes new autoscaling options possible
 #      autoScalingGroup:
 #        minSize: 1
 #        maxSize: 3
 #        rollingUpdateMinInstancesInService: 2
+#
+#        # Configure mixedInstances for autoscalinggroups
+#        # See https://aws.amazon.com/blogs/aws/new-ec2-auto-scaling-groups-with-multiple-instance-types-purchase-options/
+#        # and https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-autoscaling-autoscalinggroup-instancesdistribution.html for valid values
+#        mixedInstances:
+#          enabled: false
+#          onDemandAllocationStrategy: prioritized
+#          onDemandBaseCapacity: 0
+#          onDemandPercentageAboveBaseCapacity: 0
+#          spotAllocationStrategy: lowest-price
+#          spotInstancePools: 2
+#          spotMaxPrice: 2
+#          instanceTypes:
+#          - t2.medium
+#          - t3.medium
 #
 #      #
 #      # Spot fleet config for worker nodes

--- a/builtin/files/cluster.yaml.tmpl
+++ b/builtin/files/cluster.yaml.tmpl
@@ -473,6 +473,7 @@ worker:
 #        # Configure mixedInstances for autoscalinggroups
 #        # See https://aws.amazon.com/blogs/aws/new-ec2-auto-scaling-groups-with-multiple-instance-types-purchase-options/
 #        # and https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-autoscaling-autoscalinggroup-instancesdistribution.html for valid values
+#        # NOTE: mixedInstances and full cluster autoscaler support is being worked on at the moment see: https://github.com/kubernetes/autoscaler/pull/1473
 #        mixedInstances:
 #          enabled: false
 #          onDemandAllocationStrategy: prioritized

--- a/builtin/files/stack-templates/node-pool.json.tmpl
+++ b/builtin/files/stack-templates/node-pool.json.tmpl
@@ -135,8 +135,10 @@
             {{if .AutoScalingGroup.MixedInstances.SpotAllocationStrategy}}
             "SpotAllocationStrategy" : "{{.AutoScalingGroup.MixedInstances.SpotAllocationStrategy}}",
             {{end}}
-            "SpotInstancePools" : {{.AutoScalingGroup.MixedInstances.SpotInstancePools}},
-            "SpotMaxPrice" : "{{.AutoScalingGroup.MixedInstances.SpotMaxPrice}}"
+            {{if .AutoScalingGroup.MixedInstances.SpotMaxPrice}}
+            "SpotMaxPrice" : "{{.AutoScalingGroup.MixedInstances.SpotMaxPrice}}",
+            {{end}}
+            "SpotInstancePools" : {{.AutoScalingGroup.MixedInstances.SpotInstancePools}}
           },
           "LaunchTemplate" : {
             "LaunchTemplateSpecification" : {

--- a/builtin/files/stack-templates/node-pool.json.tmpl
+++ b/builtin/files/stack-templates/node-pool.json.tmpl
@@ -113,12 +113,10 @@
 {{end}}
 {{define "AutoScaling"}}
     "{{.LogicalName}}": {
+      "DependsOn": "{{.LaunchTemplateLogicalName}}",
       "Properties": {
         "HealthCheckGracePeriod": 600,
         "HealthCheckType": "EC2",
-        "LaunchConfigurationName": {
-          "Ref": "{{.LaunchConfigurationLogicalName}}"
-        },
         "MaxSize": "{{.MaxCount}}",
         "MetricsCollection": [
           {
@@ -126,6 +124,41 @@
           }
         ],
         "MinSize": "{{.MinCount}}",
+        {{if .AutoScalingGroup.MixedInstances.Enabled }}
+        "MixedInstancesPolicy": {
+          "InstancesDistribution" : {
+            {{if .AutoScalingGroup.MixedInstances.OnDemandAllocationStrategy}}
+            "OnDemandAllocationStrategy" : "{{.AutoScalingGroup.MixedInstances.OnDemandAllocationStrategy}}",
+            {{end}}
+            "OnDemandBaseCapacity" : {{.AutoScalingGroup.MixedInstances.OnDemandBaseCapacity}},
+            "OnDemandPercentageAboveBaseCapacity" : {{.AutoScalingGroup.MixedInstances.OnDemandPercentageAboveBaseCapacity}},
+            {{if .AutoScalingGroup.MixedInstances.SpotAllocationStrategy}}
+            "SpotAllocationStrategy" : "{{.AutoScalingGroup.MixedInstances.SpotAllocationStrategy}}",
+            {{end}}
+            "SpotInstancePools" : {{.AutoScalingGroup.MixedInstances.SpotInstancePools}},
+            "SpotMaxPrice" : "{{.AutoScalingGroup.MixedInstances.SpotMaxPrice}}"
+          },
+          "LaunchTemplate" : {
+            "LaunchTemplateSpecification" : {
+              "LaunchTemplateId": { "Ref": "{{.LaunchTemplateLogicalName}}" },
+              "Version": { "Fn::GetAtt" : [ "{{.LaunchTemplateLogicalName}}", "LatestVersionNumber" ] }
+            },
+            "Overrides" : [
+              {{range $index, $instanceType := .AutoScalingGroup.MixedInstances.InstanceTypes}}
+              {{if $index}},{{end}}
+              {
+                "InstanceType": "{{$instanceType}}"
+              }
+              {{end}}
+            ]
+          }
+        },
+        {{else}}
+        "LaunchTemplate": {
+          "LaunchTemplateId": { "Ref": "{{.LaunchTemplateLogicalName}}" },
+          "Version": { "Fn::GetAtt" : [ "{{.LaunchTemplateLogicalName}}", "LatestVersionNumber" ] }
+        },
+        {{end}}
         "Tags": [
           {{if .Autoscaling.ClusterAutoscaler.Enabled}}
           {
@@ -223,66 +256,79 @@
       "Type" : "AWS::AutoScaling::LifecycleHook"
     },
     {{end}}
-    "{{.LaunchConfigurationLogicalName}}": {
+    "{{.LaunchTemplateLogicalName}}": {
       "Properties": {
-        "BlockDeviceMappings": [
-          {
-            "DeviceName": "/dev/xvda",
-            "Ebs": {
-              "VolumeSize": "{{.RootVolume.Size}}",
-              {{if gt .RootVolume.IOPS 0}}
-              "Iops": "{{.RootVolume.IOPS}}",
-              {{end}}
-              "VolumeType": "{{.RootVolume.Type}}"
-            }
-          }{{range $volumeMountSpecIndex, $volumeMountSpec := .VolumeMounts}},
-          {
-            "DeviceName": "{{$volumeMountSpec.Device}}",
-            "Ebs": {
-              "VolumeSize": "{{$volumeMountSpec.Size}}",
-              {{if gt $volumeMountSpec.Iops 0}}
-              "Iops": "{{$volumeMountSpec.Iops}}",
-              {{end}}
-              "VolumeType": "{{$volumeMountSpec.Type}}"
-            }
-          }{{- end -}}{{range $raid0MountSpecIndex, $raid0MountSpec := $.Raid0Mounts}}{{range $DeviceIndex, $Device := $raid0MountSpec.Devices}},
+        "LaunchTemplateName": "{{.NodePoolName}}",
+        "LaunchTemplateData": {
+          "BlockDeviceMappings": [
             {
-              "DeviceName": "{{$Device}}",
+              "DeviceName": "/dev/xvda",
               "Ebs": {
-                "VolumeSize": "{{$raid0MountSpec.Size}}",
-                {{if gt $raid0MountSpec.Iops 0}}
-                "Iops": "{{$raid0MountSpec.Iops}}",
+                "VolumeSize": "{{.RootVolume.Size}}",
+                {{if gt .RootVolume.IOPS 0}}
+                "Iops": "{{.RootVolume.IOPS}}",
                 {{end}}
-                "VolumeType": "{{$raid0MountSpec.Type}}"
+                "VolumeType": "{{.RootVolume.Type}}"
               }
-            }{{end}}
-          {{- end -}}
-        ],
-         {{if .IAMConfig.InstanceProfile.Arn }}
-        "IamInstanceProfile": "{{.IAMConfig.InstanceProfile.Arn}}",
-        {{else}}
-        "IamInstanceProfile": { "Ref": "IAMInstanceProfileWorker" },
-        {{end}}
-        "ImageId": "{{.AMI}}",
-        "InstanceType": "{{.InstanceType}}",
-        {{if .KeyName}}"KeyName": "{{.KeyName}}",{{end}}
-        "SecurityGroups": [
-          {{range $sgIndex, $sgRef := $.SecurityGroupRefs}}
-          {{if gt $sgIndex 0}},{{end}}
-          {{$sgRef}}
+            }{{range $volumeMountSpecIndex, $volumeMountSpec := .VolumeMounts}},
+            {
+              "DeviceName": "{{$volumeMountSpec.Device}}",
+              "Ebs": {
+                "VolumeSize": "{{$volumeMountSpec.Size}}",
+                {{if gt $volumeMountSpec.Iops 0}}
+                "Iops": "{{$volumeMountSpec.Iops}}",
+                {{end}}
+                "VolumeType": "{{$volumeMountSpec.Type}}"
+              }
+            }{{- end -}}{{range $raid0MountSpecIndex, $raid0MountSpec := $.Raid0Mounts}}{{range $DeviceIndex, $Device := $raid0MountSpec.Devices}},
+              {
+                "DeviceName": "{{$Device}}",
+                "Ebs": {
+                  "VolumeSize": "{{$raid0MountSpec.Size}}",
+                  {{if gt $raid0MountSpec.Iops 0}}
+                  "Iops": "{{$raid0MountSpec.Iops}}",
+                  {{end}}
+                  "VolumeType": "{{$raid0MountSpec.Type}}"
+                }
+              }{{end}}
+            {{- end -}}
+          ],
+          "IamInstanceProfile": {
+             {{if .IAMConfig.InstanceProfile.Arn }}
+              "Arn": "{{.IAMConfig.InstanceProfile.Arn}}"
+            {{else}}
+              "Name": { "Ref": "IAMInstanceProfileWorker" }
+            {{end}}
+          },
+          "ImageId": "{{.AMI}}",
+          "InstanceType": "{{.InstanceType}}",
+          {{if .KeyName}}"KeyName": "{{.KeyName}}",{{end}}
+          "SecurityGroupIds": [
+            {{range $sgIndex, $sgRef := $.SecurityGroupRefs}}
+            {{if gt $sgIndex 0}},{{end}}
+            {{$sgRef}}
+            {{end}}
+          ],
+          {{if not .AutoScalingGroup.MixedInstances.Enabled }}
+            {{if .SpotPrice}}
+              "InstanceMarketOptions": {
+                "MarketType": "spot",
+                "SpotOptions": {
+                  "MaxPrice": "{{.SpotPrice}}"
+                }
+              },
+            {{end}}
+            {{if EbsOptimized .InstanceType }}
+              "EbsOptimized": "true",
+            {{end}}
           {{end}}
-        ],
-        {{if .SpotPrice}}
-        "SpotPrice": {{.SpotPrice}},
-        {{else}}
-        "PlacementTenancy": "{{.Tenancy}}",
-        {{end}}
-        {{if EbsOptimized .InstanceType }}
-        "EbsOptimized": "true",
-        {{end}}
-        "UserData": {{ .UserDataWorker.Parts.instance.Template }}
+          "Placement": {
+            "Tenancy": "{{.Tenancy}}"
+          },
+          "UserData": {{ .UserDataWorker.Parts.instance.Template }}
+        }
       },
-      "Type": "AWS::AutoScaling::LaunchConfiguration"
+      "Type": "AWS::EC2::LaunchTemplate"
     {{if not .IAMConfig.InstanceProfile.Arn}}
     },
     {{else}}

--- a/pkg/api/asg.go
+++ b/pkg/api/asg.go
@@ -6,9 +6,10 @@ import (
 
 // Configuration specific to auto scaling groups
 type AutoScalingGroup struct {
-	MinSize                            *int `yaml:"minSize,omitempty"`
-	MaxSize                            int  `yaml:"maxSize,omitempty"`
-	RollingUpdateMinInstancesInService *int `yaml:"rollingUpdateMinInstancesInService,omitempty"`
+	MinSize                            *int           `yaml:"minSize,omitempty"`
+	MaxSize                            int            `yaml:"maxSize,omitempty"`
+	RollingUpdateMinInstancesInService *int           `yaml:"rollingUpdateMinInstancesInService,omitempty"`
+	MixedInstances                     MixedInstances `yaml:"mixedInstances,omitempty"`
 	UnknownKeys                        `yaml:",inline"`
 }
 
@@ -21,10 +22,13 @@ func (asg AutoScalingGroup) Validate() error {
 	}
 	if asg.MinSize != nil && *asg.MinSize > asg.MaxSize {
 		return fmt.Errorf("`autoScalingGroup.minSize` (%d) must be less than or equal to `autoScalingGroup.maxSize` (%d), if you have specified only minSize please specify maxSize as well",
-			asg.MinSize, asg.MaxSize)
+			*asg.MinSize, asg.MaxSize)
 	}
 	if asg.RollingUpdateMinInstancesInService != nil && *asg.RollingUpdateMinInstancesInService < 0 {
 		return fmt.Errorf("`autoScalingGroup.rollingUpdateMinInstancesInService` must be greater than or equal to 0 but was %d", *asg.RollingUpdateMinInstancesInService)
+	}
+	if asg.MixedInstances.Enabled {
+		return asg.MixedInstances.Validate()
 	}
 	return nil
 }

--- a/pkg/api/asg_test.go
+++ b/pkg/api/asg_test.go
@@ -1,0 +1,113 @@
+package api
+
+import (
+	"github.com/stretchr/testify/require"
+	"testing"
+)
+
+func TestValidateAsgSizes(t *testing.T) {
+	var minSize int
+	var rolMinInst int
+	a := AutoScalingGroup{
+		MinSize:                            &minSize,
+		RollingUpdateMinInstancesInService: &rolMinInst,
+	}
+
+	err := a.Validate()
+	require.NoError(t, err)
+
+	// Expect error if minSize is negative
+	minSize = -1
+	err = a.Validate()
+	require.EqualError(t, err, "`autoScalingGroup.minSize` must be zero or greater if specified")
+	minSize = 1
+
+	// Expect error if maxSize is negative
+	a.MaxSize = -1
+	err = a.Validate()
+	require.EqualError(t, err, "`autoScalingGroup.maxSize` must be zero or greater if specified")
+	a.MaxSize = 3
+
+	// Expect error is minSize > maxSize
+	minSize = 5
+	err = a.Validate()
+	require.EqualError(t, err, "`autoScalingGroup.minSize` (5) must be less than or equal to `autoScalingGroup.maxSize` (3), if you have specified only minSize please specify maxSize as well")
+	minSize = 1
+
+	// Expect error if rollingUpdate is negative
+	rolMinInst = -1
+	err = a.Validate()
+	require.EqualError(t, err, "`autoScalingGroup.rollingUpdateMinInstancesInService` must be greater than or equal to 0 but was -1")
+	rolMinInst = 1
+}
+
+func TestValidateAsgMixedInstances(t *testing.T) {
+	a := AutoScalingGroup{
+		MixedInstances: MixedInstances{
+			Enabled: false,
+		},
+	}
+
+	// Expect no error if MixedInstances are not enabled
+	err := a.Validate()
+	require.NoError(t, err)
+
+	// Expect no error if mixed instances are enabled with default values
+	a.MixedInstances.Enabled = true
+	err = a.Validate()
+	require.NoError(t, err)
+
+	// Expect error if string fields set to incorrect values
+	a.MixedInstances.OnDemandAllocationStrategy = "invalid-value"
+	err = a.Validate()
+	require.EqualError(t, err, "`mixedInstances.onDemandAllocationStrategy` must be equal to 'prioritized' if specified")
+	a.MixedInstances.OnDemandAllocationStrategy = "prioritized"
+	a.MixedInstances.SpotAllocationStrategy = "invalid-value"
+	err = a.Validate()
+	require.EqualError(t, err, "`mixedInstances.spotAllocationStrategy` must be equal to 'lowest-price' if specified")
+
+	// Expect no error if string fields set to correct values
+	a.MixedInstances.SpotAllocationStrategy = "lowest-price"
+	err = a.Validate()
+	require.NoError(t, err)
+
+	// Testing invalid values (out of range) for some fields
+	a.MixedInstances.OnDemandBaseCapacity = -1
+	err = a.Validate()
+	require.EqualError(t, err, "`mixedInstances.onDemandBaseCapacity` (-1) must be zero or greater if specified")
+	a.MixedInstances.OnDemandBaseCapacity = 10
+
+	a.MixedInstances.OnDemandPercentageAboveBaseCapacity = 102
+	err = a.Validate()
+	require.EqualError(t, err, "`mixedInstances.onDemandPercentageAboveBaseCapacity` (102) must be in range 0-100")
+
+	a.MixedInstances.OnDemandPercentageAboveBaseCapacity = -1
+	err = a.Validate()
+	require.EqualError(t, err, "`mixedInstances.onDemandPercentageAboveBaseCapacity` (-1) must be in range 0-100")
+
+	// Within ranges, everything should be fine again
+	a.MixedInstances.OnDemandPercentageAboveBaseCapacity = 42
+	a.MixedInstances.SpotInstancePools = 10
+	err = a.Validate()
+	require.NoError(t, err)
+
+	// More out of range
+	a.MixedInstances.SpotInstancePools = 42
+	err = a.Validate()
+	require.EqualError(t, err, "`mixedInstances.spotInstancePools` (42) must be in range 0-20")
+
+	a.MixedInstances.SpotInstancePools = -1
+	err = a.Validate()
+	require.EqualError(t, err, "`mixedInstances.spotInstancePools` (-1) must be in range 0-20")
+	a.MixedInstances.SpotInstancePools = 10
+
+	// Last error: too long string for SpotPrice
+	a.MixedInstances.SpotMaxPrice = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+	err = a.Validate()
+	require.EqualError(t, err, "`mixedInstances.spotMaxPrice` can have a maximum length of 255")
+
+	// Every field filled with a valid value, no error expected
+	a.MixedInstances.SpotMaxPrice = "2"
+	err = a.Validate()
+	require.NoError(t, err)
+}

--- a/pkg/api/mixed_instances.go
+++ b/pkg/api/mixed_instances.go
@@ -1,0 +1,38 @@
+package api
+
+import "fmt"
+
+type MixedInstances struct {
+	Enabled                             bool     `yaml:"enabled,omitempty"`
+	OnDemandAllocationStrategy          string   `yaml:"onDemandAllocationStrategy,omitempty"`
+	OnDemandBaseCapacity                int      `yaml:"onDemandBaseCapacity,omitempty"`
+	OnDemandPercentageAboveBaseCapacity int      `yaml:"onDemandPercentageAboveBaseCapacity,omitempty"`
+	SpotAllocationStrategy              string   `yaml:"spotAllocationStrategy,omitempty"`
+	SpotInstancePools                   int      `yaml:"spotInstancePools,omitempty"`
+	SpotMaxPrice                        string   `yaml:"spotMaxPrice,omitempty"`
+	InstanceTypes                       []string `yaml:"instanceTypes,omitempty"`
+}
+
+func (mi MixedInstances) Validate() error {
+	// See https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-autoscaling-autoscalinggroup-instancesdistribution.html for valid values
+	if mi.OnDemandAllocationStrategy != "" && mi.OnDemandAllocationStrategy != "prioritized" {
+		return fmt.Errorf("`mixedInstances.onDemandAllocationStrategy` must be equal to 'prioritized' if specified")
+	}
+	if mi.OnDemandBaseCapacity < 0 {
+		return fmt.Errorf("`mixedInstances.onDemandBaseCapacity` (%d) must be zero or greater if specified", mi.OnDemandBaseCapacity)
+	}
+	if mi.OnDemandPercentageAboveBaseCapacity < 0 || mi.OnDemandPercentageAboveBaseCapacity > 100 {
+		return fmt.Errorf("`mixedInstances.onDemandPercentageAboveBaseCapacity` (%d) must be in range 0-100", mi.OnDemandPercentageAboveBaseCapacity)
+	}
+	if mi.SpotAllocationStrategy != "" && mi.SpotAllocationStrategy != "lowest-price" {
+		return fmt.Errorf("`mixedInstances.spotAllocationStrategy` must be equal to 'lowest-price' if specified")
+	}
+	if mi.SpotInstancePools < 0 || mi.SpotInstancePools > 20 {
+		return fmt.Errorf("`mixedInstances.spotInstancePools` (%d) must be in range 0-20", mi.SpotInstancePools)
+	}
+	if len(mi.SpotMaxPrice) > 255 {
+		return fmt.Errorf("`mixedInstances.spotMaxPrice` can have a maximum length of 255")
+	}
+
+	return nil
+}

--- a/pkg/api/worker_node_pool.go
+++ b/pkg/api/worker_node_pool.go
@@ -99,6 +99,10 @@ func (c WorkerNodePool) LaunchConfigurationLogicalName() string {
 	return c.LogicalName() + "LC"
 }
 
+func (c WorkerNodePool) LaunchTemplateLogicalName() string {
+	return c.LogicalName() + "LT"
+}
+
 // NodePoolLogicalName returns a sanitized name of this pool which is usable as a valid cloudformation nested stack name
 func (c WorkerNodePool) NodePoolLogicalName() string {
 	return naming.FromStackToCfnResource(c.NodePoolName)


### PR DESCRIPTION
AWS recently introduced the option of using autoscalinggroups and combine multiple instances.
https://aws.amazon.com/blogs/aws/new-ec2-auto-scaling-groups-with-multiple-instance-types-purchase-options/

This PR changes the CF LaunchConfiguration templates into CF [LaunchTemplates](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-launchtemplate.html), which will add the ability to combine multiple instance types within an AutoScalingGroup.

Please let me know what you think about this! (since it's quite a refactor in the CF node pool template).

Related issue: https://github.com/kubernetes-incubator/kube-aws/issues/1500