### PR TITLE
[v0.13.x] - Allow an AntiAffinty tolerant to help ensure even spread of DNS pods

### DIFF
--- a/builtin/files/cluster.yaml.tmpl
+++ b/builtin/files/cluster.yaml.tmpl
@@ -1334,6 +1334,9 @@ kubeDns:
   # When enabled, will deploy kube-dns to K8s controllers instead of workers.
   # deployToControllers: false
 
+  # When enabled, will attempt to deploy kube-dns to nodes in different AZs, useful when autoscaling or deploying to nodes.
+  # antiAffinityAvailabilityZone: false
+
   # DNS Autoscaler
   # Ref: https://github.com/kubernetes-incubator/cluster-proportional-autoscaler/
   autoscaler:

--- a/builtin/files/userdata/cloud-config-controller
+++ b/builtin/files/userdata/cloud-config-controller
@@ -4032,15 +4032,14 @@ write_files:
                         - "master"
                 {{- end }}
                 {{- if .KubeDns.AntiAffinityAvailabilityZone }}
-                affinity:
-                  podAntiAffinity:
-                    preferredDuringSchedulingIgnoredDuringExecution:
-                      podAffinityTerm:
-                        labelSelector:
-                        - matchExpressions:
-                            - key: k8s-app
-                            operator: In
-                            values:
+                podAntiAffinity:
+                  preferredDuringSchedulingIgnoredDuringExecution:
+                    podAffinityTerm:
+                      labelSelector:
+                      - matchExpressions:
+                        - key: k8s-app
+                          operator: In
+                          values:
                             - "kube-dns"
                       topologyKey: "failure-domain.beta.kubernetes.io/zone"
                 {{- end }}

--- a/builtin/files/userdata/cloud-config-controller
+++ b/builtin/files/userdata/cloud-config-controller
@@ -4026,7 +4026,7 @@ write_files:
                   requiredDuringSchedulingIgnoredDuringExecution:
                     nodeSelectorTerms:
                     - matchExpressions:
-                        - key: node.kubernetes.io/role
+                      - key: kubernetes.io/role
                         operator: In
                         values:
                         - "master"
@@ -4045,12 +4045,12 @@ write_files:
                       topologyKey: "failure-domain.beta.kubernetes.io/zone"
                 {{- end }}
               tolerations:
-              - key: "CriticalAddonsOnly"
-                  operator: "Exists"
-              - key: "node.alpha.kubernetes.io/role"
-                operator: "Equal"
-                value: "master"
-                effect: "NoSchedule"
+               - key: "CriticalAddonsOnly"
+                 operator: "Exists"
+               - key: "node.alpha.kubernetes.io/role"
+                 operator: "Equal"
+                 value: "master"
+                 effect: "NoSchedule"
               {{ else -}}
               tolerations:
               - key: "CriticalAddonsOnly"

--- a/builtin/files/userdata/cloud-config-controller
+++ b/builtin/files/userdata/cloud-config-controller
@@ -4019,24 +4019,38 @@ write_files:
             spec:
               priorityClassName: system-node-critical
               serviceAccountName: coredns
-              {{ if .KubeDns.DeployToControllers -}}
+              {{ if or .KubeDns.DeployToControllers .KubeDns.AntiAffinityAvailabilityZone -}}
               affinity:
+                {{- if .KubeDns.DeployToControllers }}
                 nodeAffinity:
                   requiredDuringSchedulingIgnoredDuringExecution:
-                    nodeSelectorTerms:
-                    - matchExpressions:
-                      - key: kubernetes.io/role
-                        operator: In
-                        values:
-                        - "master"
-
+                  nodeSelectorTerms:
+                  - matchExpressions:
+                      - key: node.kubernetes.io/role
+                      operator: In
+                      values:
+                      - "master"
+                {{- end }}
+                {{- if .KubeDns.AntiAffinityAvailabilityZone }}
+                affinity:
+                  podAntiAffinity:
+                  preferredDuringSchedulingIgnoredDuringExecution:
+                      podAffinityTerm:
+                      labelSelector:
+                      - matchExpressions:
+                          - key: k8s-app
+                          operator: In
+                          values:
+                          - "kube-dns"
+                      topologyKey: "failure-domain.beta.kubernetes.io/zone"
+                {{- end }}
               tolerations:
-               - key: "CriticalAddonsOnly"
-                 operator: "Exists"
-               - key: "node.alpha.kubernetes.io/role"
-                 operator: "Equal"
-                 value: "master"
-                 effect: "NoSchedule"
+              - key: "CriticalAddonsOnly"
+                  operator: "Exists"
+              - key: "node.alpha.kubernetes.io/role"
+                operator: "Equal"
+                value: "master"
+                effect: "NoSchedule"
               {{ else -}}
               tolerations:
               - key: "CriticalAddonsOnly"

--- a/builtin/files/userdata/cloud-config-controller
+++ b/builtin/files/userdata/cloud-config-controller
@@ -4024,24 +4024,24 @@ write_files:
                 {{- if .KubeDns.DeployToControllers }}
                 nodeAffinity:
                   requiredDuringSchedulingIgnoredDuringExecution:
-                  nodeSelectorTerms:
-                  - matchExpressions:
-                      - key: node.kubernetes.io/role
-                      operator: In
-                      values:
-                      - "master"
+                    nodeSelectorTerms:
+                    - matchExpressions:
+                        - key: node.kubernetes.io/role
+                        operator: In
+                        values:
+                        - "master"
                 {{- end }}
                 {{- if .KubeDns.AntiAffinityAvailabilityZone }}
                 affinity:
                   podAntiAffinity:
-                  preferredDuringSchedulingIgnoredDuringExecution:
+                    preferredDuringSchedulingIgnoredDuringExecution:
                       podAffinityTerm:
-                      labelSelector:
-                      - matchExpressions:
-                          - key: k8s-app
-                          operator: In
-                          values:
-                          - "kube-dns"
+                        labelSelector:
+                        - matchExpressions:
+                            - key: k8s-app
+                            operator: In
+                            values:
+                            - "kube-dns"
                       topologyKey: "failure-domain.beta.kubernetes.io/zone"
                 {{- end }}
               tolerations:

--- a/pkg/api/cluster.go
+++ b/pkg/api/cluster.go
@@ -161,10 +161,11 @@ func NewDefaultCluster() *Cluster {
 				IPVSMode: ipvsMode,
 			},
 			KubeDns: KubeDns{
-				Provider:            "coredns",
-				NodeLocalResolver:   false,
-				DeployToControllers: false,
-				TTL:                 30,
+				Provider:                     "coredns",
+				NodeLocalResolver:            false,
+				DeployToControllers:          false,
+				AntiAffinityAvailabilityZone: false,
+				TTL:                          30,
 				Autoscaler: KubeDnsAutoscaler{
 					CoresPerReplica: 256,
 					NodesPerReplica: 16,

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -211,12 +211,13 @@ type KubeDnsAutoscaler struct {
 }
 
 type KubeDns struct {
-	Provider                 string            `yaml:"provider"`
-	NodeLocalResolver        bool              `yaml:"nodeLocalResolver"`
-	NodeLocalResolverOptions []string          `yaml:"nodeLocalResolverOptions"`
-	DeployToControllers      bool              `yaml:"deployToControllers"`
-	TTL                      int               `yaml:"ttl"`
-	Autoscaler               KubeDnsAutoscaler `yaml:"autoscaler"`
+	Provider                     string            `yaml:"provider"`
+	NodeLocalResolver            bool              `yaml:"nodeLocalResolver"`
+	NodeLocalResolverOptions     []string          `yaml:"nodeLocalResolverOptions"`
+	DeployToControllers          bool              `yaml:"deployToControllers"`
+	AntiAffinityAvailabilityZone bool              `yaml:"antiAffinityAvailabilityZone"`
+	TTL                          int               `yaml:"ttl"`
+	Autoscaler                   KubeDnsAutoscaler `yaml:"autoscaler"`
 }
 
 func (c *KubeDns) MergeIfEmpty(other KubeDns) {

--- a/pkg/model/cluster_test.go
+++ b/pkg/model/cluster_test.go
@@ -1119,10 +1119,11 @@ func TestKubeDns(t *testing.T) {
 			conf: `
 `,
 			kubeDns: api.KubeDns{
-				Provider:            "coredns",
-				NodeLocalResolver:   false,
-				DeployToControllers: false,
-				TTL:                 30,
+				Provider:                     "coredns",
+				NodeLocalResolver:            false,
+				DeployToControllers:          false,
+				AntiAffinityAvailabilityZone: false,
+				TTL:                          30,
 				Autoscaler: api.KubeDnsAutoscaler{
 					CoresPerReplica: 256,
 					NodesPerReplica: 16,
@@ -1137,10 +1138,49 @@ kubeDns:
   deployToControllers: false
 `,
 			kubeDns: api.KubeDns{
-				Provider:            "coredns",
-				NodeLocalResolver:   false,
-				DeployToControllers: false,
-				TTL:                 30,
+				Provider:                     "coredns",
+				NodeLocalResolver:            false,
+				DeployToControllers:          false,
+				AntiAffinityAvailabilityZone: false,
+				TTL:                          30,
+				Autoscaler: api.KubeDnsAutoscaler{
+					CoresPerReplica: 256,
+					NodesPerReplica: 16,
+					Min:             2,
+				},
+			},
+		},
+		{
+			conf: `
+kubeDns:
+  deployToControllers: false
+  antiAffinityAvailabilityZone: true
+`,
+			kubeDns: api.KubeDns{
+				Provider:                     "coredns",
+				NodeLocalResolver:            false,
+				DeployToControllers:          false,
+				AntiAffinityAvailabilityZone: true,
+				TTL:                          30,
+				Autoscaler: api.KubeDnsAutoscaler{
+					CoresPerReplica: 256,
+					NodesPerReplica: 16,
+					Min:             2,
+				},
+			},
+		},
+		{
+			conf: `
+kubeDns:
+  deployToControllers: true
+  antiAffinityAvailabilityZone: true
+`,
+			kubeDns: api.KubeDns{
+				Provider:                     "coredns",
+				NodeLocalResolver:            false,
+				DeployToControllers:          true,
+				AntiAffinityAvailabilityZone: true,
+				TTL:                          30,
 				Autoscaler: api.KubeDnsAutoscaler{
 					CoresPerReplica: 256,
 					NodesPerReplica: 16,
@@ -1159,10 +1199,11 @@ kubeDns:
     min: 15
 `,
 			kubeDns: api.KubeDns{
-				Provider:            "coredns",
-				NodeLocalResolver:   true,
-				DeployToControllers: true,
-				TTL:                 30,
+				Provider:                     "coredns",
+				NodeLocalResolver:            true,
+				DeployToControllers:          true,
+				AntiAffinityAvailabilityZone: false,
+				TTL:                          30,
 				Autoscaler: api.KubeDnsAutoscaler{
 					CoresPerReplica: 5,
 					NodesPerReplica: 10,
@@ -1176,10 +1217,11 @@ kubeDns:
   provider: coredns
 `,
 			kubeDns: api.KubeDns{
-				Provider:            "coredns",
-				NodeLocalResolver:   false,
-				DeployToControllers: false,
-				TTL:                 30,
+				Provider:                     "coredns",
+				NodeLocalResolver:            false,
+				DeployToControllers:          false,
+				AntiAffinityAvailabilityZone: false,
+				TTL:                          30,
 				Autoscaler: api.KubeDnsAutoscaler{
 					CoresPerReplica: 256,
 					NodesPerReplica: 16,
@@ -1194,10 +1236,11 @@ kubeDns:
   ttl: 5
 `,
 			kubeDns: api.KubeDns{
-				Provider:            "coredns",
-				NodeLocalResolver:   false,
-				DeployToControllers: false,
-				TTL:                 5,
+				Provider:                     "coredns",
+				NodeLocalResolver:            false,
+				DeployToControllers:          false,
+				AntiAffinityAvailabilityZone: false,
+				TTL:                          5,
 				Autoscaler: api.KubeDnsAutoscaler{
 					CoresPerReplica: 256,
 					NodesPerReplica: 16,


### PR DESCRIPTION
## Changes

- Adds a preferred scheduling anti-affinity to try and target nodes in different AZs if enabled. 

Useful in situations where we have autoscaling enabled or are deploying DNS pods to nodes.