### PR TITLE
Adding in the metricsBindAddress to kube-proxy configmap to allow for…

### DIFF
--- a/builtin/files/userdata/cloud-config-controller
+++ b/builtin/files/userdata/cloud-config-controller
@@ -3192,6 +3192,7 @@ write_files:
           apiVersion: {{if checkVersion ">=1.9" .K8sVer}}kubeproxy.config.k8s.io{{else}}componentconfig{{end}}/v1alpha1
           kind: KubeProxyConfiguration
           bindAddress: 0.0.0.0
+          metricsBindAddress: 0.0.0.0:10249
           {{range $flag,$value := .KubeProxy.Config -}}
           {{$flag}}: {{$value}}
           {{ end -}}


### PR DESCRIPTION
Adding in a new configuration to kube-proxy's configmap, so can allow a monitoring system to scrape kube-proxy's metric endpoint. 