### PR TITLE
[v0.16.1] Fix rendering for openICMP

### DIFF
--- a/builtin/files/stack-templates/control-plane.json.tmpl
+++ b/builtin/files/stack-templates/control-plane.json.tmpl
@@ -219,7 +219,8 @@
             "ToPort": -1
           },
           {{end -}}
-          {{ range $_, $r := $.SSHAccessAllowedSourceCIDRs -}}
+          {{ range $i, $r := $.SSHAccessAllowedSourceCIDRs -}}
+          {{if gt $i 0}},{{end}}
           {
             "CidrIp": "{{$r}}",
             "FromPort": 22,


### PR DESCRIPTION
## Changes

Rendering for the new `openICMP` feature was broken when more than one addressed was assigned to `sshAccessAllowedSourceCIDRs`, this fixes it.