### PR TITLE
[v1.16.1] Update API version for deployment, as v1beta1 is deprecated.

### DIFF
--- a/builtin/files/userdata/cloud-config-controller
+++ b/builtin/files/userdata/cloud-config-controller
@@ -1371,7 +1371,7 @@ write_files:
       ---
       # This manifest creates a Deployment of Typha to back the above service.
 
-      apiVersion: apps/v1beta1
+      apiVersion: apps/v1
       kind: Deployment
       metadata:
         name: calico-typha


### PR DESCRIPTION
## Changes

- `apps/v1beta1` has been deprecated, we need to remove reference to it.