### PR TITLE
Remove danielfm from OWNERS and SECURITY_CONTACTS

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -10,7 +10,6 @@ reviewers:
 - redbaron
 approvers:
 - c-knowles
-- danielfm
 - davidmccormick
 - dominicgunn
 - mumoshu

--- a/SECURITY_CONTACTS
+++ b/SECURITY_CONTACTS
@@ -12,6 +12,5 @@
 
 c-knowles
 camilb
-danielfm
 mumoshu
 redbaron


### PR DESCRIPTION
Unfortunately, I've been working for a different company for the past couple of years in which I no longer use Kubernetes in AWS, so I became quite outdated with how things are progressing in this project. For this reason, it is with great sadness that I'm stepping down as one of the maintainers of kube-aws. :cry: 

I thank each of the current - and past - maintainers for the patience and opportunity for letting me help you a little with this great project, and I'm sure it stays in good hands.

See you! :smile: 